### PR TITLE
修复dubbo 版本号2.5.4-SNAPSHOT无法在中央仓库找到bug

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <spring-boot.version>1.5.3.RELEASE</spring-boot.version>
-        <dubbo.version>2.5.4-SNAPSHOT</dubbo.version>
+        <dubbo.version>2.5.4</dubbo.version>
         <zkclient.version>0.10</zkclient.version>
 
         <version.compiler-plugin>3.5.1</version.compiler-plugin>


### PR DESCRIPTION
构建报Could not resolve dependencies for project io.dubbo.springboot:spring-boot-starter-dubbo:jar,是因为2.5.4-SNAPSHOT已经不在中央仓库,这里我改为了2.5.4 clean package可以通过