### PR TITLE
remove dubbo-demo-api dependency from dubbo actuator test

### DIFF
--- a/dubbo-spring-boot-actuator/pom.xml
+++ b/dubbo-spring-boot-actuator/pom.xml
@@ -65,13 +65,6 @@
             <scope>test</scope>
         </dependency>
 
-        <dependency>
-            <groupId>com.alibaba</groupId>
-            <artifactId>dubbo-demo-api</artifactId>
-            <version>${dubbo.version}</version>
-            <scope>test</scope>
-        </dependency>
-
     </dependencies>
 
 </project>

--- a/dubbo-spring-boot-actuator/src/test/java/com/alibaba/boot/dubbo/actuate/endpoint/mvc/DubboMvcEndpointTest.java
+++ b/dubbo-spring-boot-actuator/src/test/java/com/alibaba/boot/dubbo/actuate/endpoint/mvc/DubboMvcEndpointTest.java
@@ -19,7 +19,6 @@ package com.alibaba.boot.dubbo.actuate.endpoint.mvc;
 import com.alibaba.boot.dubbo.actuate.endpoint.DubboEndpoint;
 import com.alibaba.boot.dubbo.autoconfigure.DubboAutoConfiguration;
 import com.alibaba.dubbo.config.annotation.Service;
-import com.alibaba.dubbo.demo.DemoService;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -137,7 +136,7 @@ public class DubboMvcEndpointTest {
 
         Assert.assertEquals(1, services.size());
 
-        Map<String, Object> demoServiceMeta = services.get("ServiceBean@com.alibaba.dubbo.demo.DemoService#dubboMvcEndpointTest.DefaultDemoService");
+        Map<String, Object> demoServiceMeta = services.get("ServiceBean@com.alibaba.boot.dubbo.actuate.endpoint.mvc.DubboMvcEndpointTest$DemoService#dubboMvcEndpointTest.DefaultDemoService");
 
         Assert.assertEquals("1.0.0", demoServiceMeta.get("version"));
 
@@ -184,6 +183,10 @@ public class DubboMvcEndpointTest {
             return "Hello, " + name + " (from Spring Boot)";
         }
 
+    }
+
+    interface DemoService {
+        String sayHello(String name);
     }
 
 }


### PR DESCRIPTION
fix #15 

hey @mercyblitz Could you take a look at this pull request and merge it as temporary fix

 I’m trying use this library via [Jitpack](https://jitpack.io/#dubbo/dubbo-spring-boot-project). Because dubbo-demo-api didn't publish to maven central, I can't make CI happy.