### PR TITLE
polish pom, remove optional dependencies in starter module

### DIFF
--- a/dubbo-spring-boot-autoconfigure/pom.xml
+++ b/dubbo-spring-boot-autoconfigure/pom.xml
@@ -17,14 +17,18 @@
 
 
     <dependencies>
-
         <!-- Spring Boot dependencies -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter</artifactId>
+            <artifactId>spring-boot-autoconfigure</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-logging</artifactId>
             <optional>true</optional>
         </dependency>
 
+        <!-- @ConfigurationProperties annotation processing (metadata for IDEs) -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-configuration-processor</artifactId>
@@ -44,7 +48,5 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
-
     </dependencies>
-
 </project>

--- a/dubbo-spring-boot-starter/pom.xml
+++ b/dubbo-spring-boot-starter/pom.xml
@@ -17,12 +17,10 @@
 
 
     <dependencies>
-
         <!-- Spring Boot dependencies -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter</artifactId>
-            <optional>true</optional>
         </dependency>
 
         <!-- Dubbo -->
@@ -33,10 +31,13 @@
 
         <dependency>
             <groupId>com.alibaba.boot</groupId>
+            <artifactId>dubbo-spring-boot-autoconfigure</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.alibaba.boot</groupId>
             <artifactId>dubbo-spring-boot-actuator</artifactId>
             <version>${project.version}</version>
         </dependency>
-
     </dependencies>
-
 </project>


### PR DESCRIPTION
As mentioned in Spring Boot Reference:

> A full Spring Boot starter for a library may contain the following components:
>
> * The autoconfigure module that contains the auto-configuration code.
> * The starter module that provides a dependency to the autoconfigure module as well as the library and any additional dependencies that are typically useful. In a nutshell, adding the starter should provide everything needed to start using that library.

### About dependencies:

* Autoconfigure Module

> You should mark the dependencies to the library as optional so that you can include the autoconfigure module in your projects more easily. If you do it that way, the library is not provided and, by default, Spring Boot backs off.

* Starter Module
>Providing a proper set of default dependencies may be hard if the number of optional dependencies is high, as you should avoid including dependencies that are unnecessary for a typical usage of the library. In other words, you should not include optional dependencies.

So I make dependencies in Autoconfigure Module optional if they can be, remove optional dependencies in Starter Module.
