### PR TITLE
update the version of sub project to real version number. It can avoi…

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,7 +356,7 @@ $ ./mvnw clean install
 <dependency>
   <groupId>com.alibaba.boot</groupId>
   <artifactId>dubbo-spring-boot-starter</artifactId>
-  <version>${revision}</version>
+  <version>1.0.0-SNAPSHOT</version>
 </dependency>
 ```
 

--- a/dubbo-spring-boot-actuator/pom.xml
+++ b/dubbo-spring-boot-actuator/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>dubbo-spring-boot-parent</artifactId>
         <groupId>com.alibaba.boot</groupId>
-        <version>${revision}</version>
+        <version>1.0.0-SNAPSHOT</version>
         <relativePath>../dubbo-spring-boot-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/dubbo-spring-boot-autoconfigure/pom.xml
+++ b/dubbo-spring-boot-autoconfigure/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.alibaba.boot</groupId>
         <artifactId>dubbo-spring-boot-parent</artifactId>
-        <version>${revision}</version>
+        <version>1.0.0-SNAPSHOT</version>
         <relativePath>../dubbo-spring-boot-parent</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/dubbo-spring-boot-parent/pom.xml
+++ b/dubbo-spring-boot-parent/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.alibaba.boot</groupId>
         <artifactId>dubbo-spring-boot-project</artifactId>
-        <version>${revision}</version>
+        <version>1.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/dubbo-spring-boot-samples/dubbo-spring-boot-sample-api/pom.xml
+++ b/dubbo-spring-boot-samples/dubbo-spring-boot-sample-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.alibaba.boot</groupId>
         <artifactId>dubbo-spring-boot-samples</artifactId>
-        <version>${revision}</version>
+        <version>1.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/dubbo-spring-boot-samples/dubbo-spring-boot-sample-consumer/pom.xml
+++ b/dubbo-spring-boot-samples/dubbo-spring-boot-sample-consumer/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.alibaba.boot</groupId>
         <artifactId>dubbo-spring-boot-samples</artifactId>
-        <version>${revision}</version>
+        <version>1.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/dubbo-spring-boot-samples/dubbo-spring-boot-sample-provider/pom.xml
+++ b/dubbo-spring-boot-samples/dubbo-spring-boot-sample-provider/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.alibaba.boot</groupId>
         <artifactId>dubbo-spring-boot-samples</artifactId>
-        <version>${revision}</version>
+        <version>1.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/dubbo-spring-boot-samples/pom.xml
+++ b/dubbo-spring-boot-samples/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.alibaba.boot</groupId>
         <artifactId>dubbo-spring-boot-parent</artifactId>
-        <version>${revision}</version>
+        <version>1.0.0-SNAPSHOT</version>
         <relativePath>../dubbo-spring-boot-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/dubbo-spring-boot-starter/pom.xml
+++ b/dubbo-spring-boot-starter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.alibaba.boot</groupId>
         <artifactId>dubbo-spring-boot-parent</artifactId>
-        <version>${revision}</version>
+        <version>1.0.0-SNAPSHOT</version>
         <relativePath>../dubbo-spring-boot-parent</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.alibaba.boot</groupId>
     <artifactId>dubbo-spring-boot-project</artifactId>
-    <version>${revision}</version>
+    <version>1.0.0-SNAPSHOT</version>
 
     <packaging>pom</packaging>
 


### PR DESCRIPTION
when you push the compiled jar to central maven or private maven such as nexux, you can find the version in` META-INF/maven/xxxxx/pom.xml `of sub project is

`${revision}`

not real value `1.0.0-SNAPSHOT` .so when you want to release the jars ,you cannot get the true version, maybe it's a bug of maven

`mvn versions:set -DnewVersion=1.0.0-SNAPSHOT` is a good command to batch update the version
